### PR TITLE
Bump webkitgtk-shell version.

### DIFF
--- a/package/webkitgtk-shell/Config.in
+++ b/package/webkitgtk-shell/Config.in
@@ -2,4 +2,4 @@ config BR2_PACKAGE_WEBKITGTK_SHELL
     bool "webkitgtk-shell"
     depends on BR2_PACKAGE_WEBKITGTK
     help
-      WIP. Move on.
+      WIP. A simple shell for Weston that displays Web content.

--- a/package/webkitgtk-shell/webkitgtk-shell.mk
+++ b/package/webkitgtk-shell/webkitgtk-shell.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WEBKITGTK_SHELL_VERSION = 916590f6617d04c01fc387e901ffc8ad1c16dc84
+WEBKITGTK_SHELL_VERSION = b9644da61bf3844fde1a6ff160a75174b7b24a17
 WEBKITGTK_SHELL_SITE = $(call github,zdobersek,webkitgtk-shell,$(WEBKITGTK_SHELL_VERSION))
 WEBKITGTK_SHELL_DEPENDENCIES = webkitgtk
 


### PR DESCRIPTION
The new version adds support for running the webkitgtk-shell program as the Weston's shell client.
