### PR TITLE
qt5webkit: bump version

### DIFF
--- a/package/qt5/qt5webkit/qt5webkit.mk
+++ b/package/qt5/qt5webkit/qt5webkit.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-QT5WEBKIT_VERSION = e29736d9632aa04d4c29ef83e130c03f4c934f26
+QT5WEBKIT_VERSION = a00a54dbf4e59b137b505d13eddbfdc8742865e1
 QT5WEBKIT_SITE = $(call github,Metrological,qtwebkit,$(QT5WEBKIT_VERSION))
 QT5WEBKIT_DEPENDENCIES = qt5base sqlite host-ruby host-gperf host-bison host-flex
 QT5WEBKIT_INSTALL_STAGING = YES
@@ -40,7 +40,8 @@ endif
 ifeq ($(BR2_USE_GSTREAMER),y)
 	QT5WEBKIT_GST_CONFIG = \
 		WEBKIT_CONFIG+=video \
-		WEBKIT_CONFIG+=use_gstreamer
+		WEBKIT_CONFIG+=use_gstreamer \
+		WEBKIT_CONFIG+=use_soup
 endif
 
 ifeq ($(BR2_USE_DEPRECATED_GSTREAMER),y)


### PR DESCRIPTION
a00a54d [Qt][WK1][SOUP] Persistent cookie storage support
70ac341 [Qt] libsoup support
904d28f Use Q_\* macro instead of their equivalent keywords
41f742b Revert "[GStreamer] disable webkitwebsrc"
4af7930 Revert "WebKit1: Cookies persistence support"
97db0b5 Merge pull request #1 from magomez/animations
a7452a3 Reduce the redraw timer period so framerate gets improved when there's CPU available.
