### PR TITLE
qt5webkit: bump and out-of-tree build support

### DIFF
--- a/package/qt5/qt5webkit/qt5webkit.mk
+++ b/package/qt5/qt5webkit/qt5webkit.mk
@@ -4,8 +4,9 @@
 #
 ################################################################################
 
-QT5WEBKIT_VERSION = 087bca386ffddeaddcfd99955a8007ff238004e7
+QT5WEBKIT_VERSION = 301d416ce591db676ff7348cbb37c24da8267f27
 QT5WEBKIT_SITE = $(call github,Metrological,qtwebkit,$(QT5WEBKIT_VERSION))
+
 QT5WEBKIT_DEPENDENCIES = qt5base sqlite host-ruby host-gperf host-bison host-flex
 QT5WEBKIT_INSTALL_STAGING = YES
 
@@ -24,6 +25,8 @@ QT5WEBKIT_DEPENDENCIES += xlib_libXext xlib_libXrender
 endif
 
 QT5WEBKIT_CONFIG = 
+QT5WEBKIT_MAKE_ENV = $(TARGET_MAKE_ENV) QMAKEPATH=$(@D)/Tools/qmake/
+QT5WEBKIT_BUILDDIR = $(@D)/build
 
 ifeq ($(BR2_PACKAGE_QT5DECLARATIVE),y)
 QT5WEBKIT_DEPENDENCIES += qt5declarative
@@ -93,43 +96,43 @@ ifeq ($(BR2_QT5WEBKIT_USE_DISCOVERY), y)
 endif
 
 define QT5WEBKIT_CONFIGURE_CMDS
-	(cd $(@D); \
-		$(TARGET_MAKE_ENV) \
+	(mkdir -p $(QT5WEBKIT_BUILDDIR); cd $(QT5WEBKIT_BUILDDIR); \
+		$(QT5WEBKIT_MAKE_ENV) \
 		$(HOST_DIR)/usr/bin/qmake \
-			$(QT5WEBKIT_CONFIG) \
+			$(QT5WEBKIT_CONFIG) ../WebKit.pro \
 	)
 endef
 
 define QT5WEBKIT_BUILD_CMDS
-	$(TARGET_MAKE_ENV) $(MAKE) -C $(@D)
+	$(QT5WEBKIT_MAKE_ENV) $(MAKE) -C $(QT5WEBKIT_BUILDDIR)
 endef
 
 define QT5WEBKIT_BUILD_MINIBROWSER
-	(cd $(@D)/Tools/MiniBrowser/qt; \
-		$(TARGET_MAKE_ENV) \
-		$(HOST_DIR)/usr/bin/qmake \
+	(mkdir -p $(QT5WEBKIT_BUILDDIR)/minibrowser; cd $(QT5WEBKIT_BUILDDIR)/minibrowser; \
+		$(QT5WEBKIT_MAKE_ENV) \
+		$(HOST_DIR)/usr/bin/qmake $(@D)/Tools/MiniBrowser/qt/MiniBrowser.pro \
 	)
-	$(TARGET_MAKE_ENV) $(MAKE) -C $(@D)/Tools/MiniBrowser/qt
+	$(QT5WEBKIT_MAKE_ENV) $(MAKE) LFLAGS="$(LFLAGS) -L$(QT5WEBKIT_BUILDDIR)/lib" -C $(QT5WEBKIT_BUILDDIR)/minibrowser
 endef
 
 define QT5WEBKIT_BUILD_TESTBROWSER
-	(cd $(@D)/Tools/QtTestBrowser; \
-		$(TARGET_MAKE_ENV) \
-		$(HOST_DIR)/usr/bin/qmake \
+	(mkdir -p $(QT5WEBKIT_BUILDDIR)/testbrowser; cd $(QT5WEBKIT_BUILDDIR)/testbrowser; \
+		$(QT5WEBKIT_MAKE_ENV) \
+		$(HOST_DIR)/usr/bin/qmake $(@D)/Tools/QtTestBrowser/QtTestBrowser.pro \
 	)
-	$(TARGET_MAKE_ENV) $(MAKE) -C $(@D)/Tools/QtTestBrowser
+	$(QT5WEBKIT_MAKE_ENV) $(MAKE) LFLAGS="$(LFLAGS) -L$(QT5WEBKIT_BUILDDIR)/lib" -C $(QT5WEBKIT_BUILDDIR)/testbrowser
 endef
 
 define QT5WEBKIT_BUILD_DUMPRENDERTREE
-	(cd $(@D)/Tools/DumpRenderTree/qt; \
-		$(TARGET_MAKE_ENV) \
-		$(HOST_DIR)/usr/bin/qmake ./DumpRenderTree.pro \
+	(mkdir -p $(QT5WEBKIT_BUILDDIR)/drt; cd $(QT5WEBKIT_BUILDDIR)/drt; \
+		$(QT5WEBKIT_MAKE_ENV) \
+		$(HOST_DIR)/usr/bin/qmake $(@D)/Tools/DumpRenderTree/qt/DumpRenderTree.pro \
 	)
-	$(TARGET_MAKE_ENV) $(MAKE) -C $(@D)/Tools/DumpRenderTree/qt
+	$(QT5WEBKIT_MAKE_ENV) $(MAKE) LFLAGS="$(LFLAGS) -L$(QT5WEBKIT_BUILDDIR)/lib" -C $(QT5WEBKIT_BUILDDIR)/drt
 endef
 
 define QT5WEBKIT_INSTALL_STAGING_CMDS
-	$(TARGET_MAKE_ENV) $(MAKE) -C $(@D) install
+	$(QT5WEBKIT_MAKE_ENV) $(MAKE) -C $(QT5WEBKIT_BUILDDIR) install
 	$(QT5_LA_PRL_FILES_FIXUP)
 endef
 
@@ -142,7 +145,7 @@ endif
 define QT5WEBKIT_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/root/.cache
 	cp -dpf $(STAGING_DIR)/usr/lib/libQt5WebKit*.so.* $(TARGET_DIR)/usr/lib
-	cp -dpf $(@D)/bin/* $(TARGET_DIR)/usr/bin/
+	cp -dpf $(QT5WEBKIT_BUILDDIR)/bin/* $(TARGET_DIR)/usr/bin/
 	$(QT5WEBKIT_INSTALL_TARGET_QMLS)
 endef
 


### PR DESCRIPTION
Build everything from qt5webkit in a dedicated directory to avoid
polluting the source directories with build artifacts.

qt5webkit changes:

301d416 Tools: .pro fixups for out-of-tree build
27dd39e WKTR: Fix build
11e4dde Tools: Fix MiniBrowser, DRT and QtTestBrowser build
a9a3dca Enclose GL related stuff in the ImageBufferQt destructor inside a ACCELERATED_2D_CANVAS
f729016 NSD: fix build when feature is disabled
