### PR TITLE
qt5webkit: bump version.

### DIFF
--- a/package/qt5/qt5webkit/qt5webkit.mk
+++ b/package/qt5/qt5webkit/qt5webkit.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-QT5WEBKIT_VERSION = 301d416ce591db676ff7348cbb37c24da8267f27
+QT5WEBKIT_VERSION = 1570f7a108337fbad0235658cd645ff5b54b2f3d
 QT5WEBKIT_SITE = $(call github,Metrological,qtwebkit,$(QT5WEBKIT_VERSION))
 
 QT5WEBKIT_DEPENDENCIES = qt5base sqlite host-ruby host-gperf host-bison host-flex


### PR DESCRIPTION
Fixes #38.

qt5webkit changes:

1570f7a Fix build when NSD is enabled.
0a122e3 GraphicsSurface support added to the canvas implementation.
        Enable canvas acceleration by default if supported.
101adcc Added GraphicsSurface implementation for EGL
