### PR TITLE
qt5webkit bump

### DIFF
--- a/package/qt5/qt5webkit/qt5webkit.mk
+++ b/package/qt5/qt5webkit/qt5webkit.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-QT5WEBKIT_VERSION = 1570f7a108337fbad0235658cd645ff5b54b2f3d
+QT5WEBKIT_VERSION = 19b20a6b5577eb9dee843c969ffe106584df53b7
 QT5WEBKIT_SITE = $(call github,Metrological,qtwebkit,$(QT5WEBKIT_VERSION))
 
 QT5WEBKIT_DEPENDENCIES = qt5base sqlite host-ruby host-gperf host-bison host-flex


### PR DESCRIPTION
19b20a6 [JSC] DFG 32_64: Use the edge's useKind instead of relying on child node prediction.

Solves #30.
