### PR TITLE
qt5: update to 5.3.0

### DIFF
--- a/package/qt5/qt5.mk
+++ b/package/qt5/qt5.mk
@@ -1,6 +1,6 @@
 QT5_VERSION_MAJOR = 5.3
-QT5_VERSION = $(QT5_VERSION_MAJOR).0-beta
-QT5_SITE = http://download.qt-project.org/development_releases/qt/$(QT5_VERSION_MAJOR)/$(QT5_VERSION)/submodules/
+QT5_VERSION = $(QT5_VERSION_MAJOR).0
+QT5_SITE = http://download.qt-project.org/official_releases/qt/$(QT5_VERSION_MAJOR)/$(QT5_VERSION)/submodules/
 include $(sort $(wildcard package/qt5/*/*.mk))
 
 define QT5_LA_PRL_FILES_FIXUP


### PR DESCRIPTION
No regression found compared to the beta.
