### PR TITLE
cairo: depend on GLib

### DIFF
--- a/package/cairo/cairo.mk
+++ b/package/cairo/cairo.mk
@@ -45,7 +45,7 @@ CAIRO_CONF_OPT = \
 	--enable-trace=no \
 	--enable-interpreter=no
 
-CAIRO_DEPENDENCIES = host-pkgconf fontconfig pixman
+CAIRO_DEPENDENCIES = host-pkgconf fontconfig pixman libglib2
 
 ifeq ($(BR2_PACKAGE_DIRECTFB),y)
 	CAIRO_CONF_OPT += --enable-directfb


### PR DESCRIPTION
This dependency is required so that cairo-gobject is built.
Cairo-gobject is then required by libgtk3.
