### PR TITLE
Move to WebKitGTK+ 2.6.

### DIFF
--- a/package/webkitgtk/webkitgtk.mk
+++ b/package/webkitgtk/webkitgtk.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WEBKITGTK_VERSION = b7969ed6e1518eb41e10a37e962e347b2d03101e
+WEBKITGTK_VERSION = f7e401272a8407bdfe251ad5549af3f5bca91afa
 WEBKITGTK_SITE = $(call github,Metrological,webkitgtk,$(WEBKITGTK_VERSION))
 WEBKITGTK_INSTALL_STAGING = YES
 WEBKITGTK_DEPENDENCIES = host-flex host-bison host-gperf host-ruby \


### PR DESCRIPTION
Switches to using all the pending changes on top of the recently-released WebKitGTK+ 2.6.
