### PR TITLE
Add support for ClearKey in qtwebkit.

### DIFF
--- a/package/gstreamer1/gst1-plugins-good/gst1-plugins-good-qtdemux-enca-encv.patch
+++ b/package/gstreamer1/gst1-plugins-good/gst1-plugins-good-qtdemux-enca-encv.patch
@@ -1,0 +1,197 @@
+diff --git a/gst/isomp4/fourcc.h b/gst/isomp4/fourcc.h
+index 4edf900..8c7fe8b 100644
+--- a/gst/isomp4/fourcc.h
++++ b/gst/isomp4/fourcc.h
+@@ -317,6 +317,14 @@ G_BEGIN_DECLS
+ #define MS_WAVE_FOURCC(codecid)  GST_MAKE_FOURCC( \
+         'm', 's', ((codecid)>>8)&0xff, ((codecid)&0xff))
+ 
++#define FOURCC_encv     GST_MAKE_FOURCC('e','n','c','v')
++#define FOURCC_enca     GST_MAKE_FOURCC('e','n','c','a')
++#define FOURCC_sinf     GST_MAKE_FOURCC('s','i','n','f')
++
++/* Portable interoperable file format (PIFF) */
++#define FOURCC_piff     GST_MAKE_FOURCC('p','i','f','f')
++#define FOURCC_pssh     GST_MAKE_FOURCC('p','s','s','h')
++
+ G_END_DECLS
+ 
+ #endif /* __FOURCC_H__ */
+diff --git a/gst/isomp4/qtdemux.c b/gst/isomp4/qtdemux.c
+index ae1491e..2c86adb 100644
+--- a/gst/isomp4/qtdemux.c
++++ b/gst/isomp4/qtdemux.c
+@@ -5266,6 +5266,7 @@ static gboolean
+ qtdemux_parse_moov (GstQTDemux * qtdemux, const guint8 * buffer, guint length)
+ {
+   GNode *cmov;
++  GNode *pssh;
+ 
+   qtdemux->moov_node = g_node_new ((guint8 *) buffer);
+ 
+@@ -5275,6 +5276,42 @@ qtdemux_parse_moov (GstQTDemux * qtdemux, const guint8 * buffer, guint length)
+   GST_DEBUG_OBJECT (qtdemux, "parsing 'moov' atom");
+   qtdemux_parse_node (qtdemux, qtdemux->moov_node, buffer, length);
+ 
++  /* Send every contiguous pssh atom as a single blob of data */
++  pssh = qtdemux_tree_get_child_by_type (qtdemux->moov_node, FOURCC_pssh);
++  if (pssh) {
++    GstAdapter *adapter;
++    gpointer data;
++    gsize data_length = 0;
++
++    adapter = gst_adapter_new ();
++    do {
++      GstBuffer *buf;
++      GstMapInfo map;
++      gsize pssh_size;
++
++      GST_DEBUG_OBJECT (qtdemux, "adding pssh atom");
++      pssh_size = GST_READ_UINT32_BE (pssh->data);
++      buf = gst_buffer_new_and_alloc (pssh_size);
++      gst_buffer_map (buf, &map, GST_MAP_WRITE);
++      memcpy (map.data, pssh->data, map.size); 
++      gst_buffer_unmap (buf, &map);
++      gst_adapter_push (adapter, buf);
++      /* append every other pssh sibling */
++      data_length += pssh_size;
++      pssh = qtdemux_tree_get_sibling_by_type (pssh, FOURCC_pssh);
++    } while (pssh);
++
++    GST_DEBUG_OBJECT (qtdemux, "sending pssh atoms");
++    data = gst_adapter_take (adapter, data_length);
++    /* for the pssh, just send the buffer completely */
++    gst_element_post_message (GST_ELEMENT (qtdemux),
++      gst_message_new_element (GST_OBJECT (qtdemux),
++          gst_structure_new ("drm-key-needed",
++              "data", G_TYPE_POINTER, data,
++              "data-length", G_TYPE_UINT, data_length, NULL)));
++    g_free (data);
++  }
++
+   cmov = qtdemux_tree_get_child_by_type (qtdemux->moov_node, FOURCC_cmov);
+   if (cmov) {
+     guint32 method;
+@@ -5340,6 +5377,7 @@ qtdemux_parse_container (GstQTDemux * qtdemux, GNode * node, const guint8 * buf,
+     }
+     len = QT_UINT32 (buf);
+     if (G_UNLIKELY (len == 0)) {
++      GST_MEMDUMP ("empty container", buf, end - buf);
+       GST_LOG_OBJECT (qtdemux, "empty container");
+       break;
+     }
+@@ -5472,6 +5510,7 @@ qtdemux_parse_node (GstQTDemux * qtdemux, GNode * node, const guint8 * buffer,
+         qtdemux_parse_container (qtdemux, node, buffer + 16, end);
+         break;
+       }
++      case FOURCC_enca:
+       case FOURCC_mp4a:
+       case FOURCC_alac:
+       {
+@@ -5605,6 +5644,12 @@ qtdemux_parse_node (GstQTDemux * qtdemux, GNode * node, const guint8 * buffer,
+         qtdemux_parse_container (qtdemux, node, buffer + 0x56, end);
+         break;
+       }
++      case FOURCC_encv:
++      {
++        GST_MEMDUMP_OBJECT (qtdemux, "encv", buffer, end - buffer);
++        qtdemux_parse_container (qtdemux, node, buffer + 0x56, end);
++        break;
++      }
+       case FOURCC_mjp2:
+       {
+         qtdemux_parse_container (qtdemux, node, buffer + 86, end);
+@@ -7225,6 +7270,47 @@ qtdemux_inspect_transformation_matrix (GstQTDemux * qtdemux,
+   }
+ }
+ 
++static gboolean
++qtdemux_parse_sinf (GstQTDemux * qtdemux, QtDemuxStream * stream,
++    GNode * sinf, guint32 * fourcc)
++{
++  GNode *frma;
++  const guint8 *frma_data;
++
++  /* now the 'frma' */
++  if (!(frma = qtdemux_tree_get_child_by_type (sinf, FOURCC_frma))) {
++    GST_WARNING_OBJECT (qtdemux, "No frma found");
++    return FALSE;
++  }
++
++  frma_data = (const guint8 *) frma->data;
++  *fourcc = QT_FOURCC (frma_data + 8);
++  return TRUE;
++}
++
++
++static gboolean
++qtdemux_parse_encx (GstQTDemux * qtdemux, QtDemuxStream * stream,
++    GNode * encx, guint32 * fourcc)
++{
++  GNode *sinf;
++
++  /* now the 'sinf' */
++  sinf = qtdemux_tree_get_child_by_type (encx, FOURCC_sinf);
++  if (!sinf) {
++    GST_WARNING_OBJECT (qtdemux, "No sinf found");
++    return FALSE;
++  }
++
++  while (sinf) {
++    if (!qtdemux_parse_sinf (qtdemux, stream, sinf, fourcc))
++      return FALSE;
++    sinf = qtdemux_tree_get_sibling_by_type (sinf, FOURCC_sinf);
++  }
++
++  return TRUE;
++}
++
+ /* parse the traks.
+  * With each track we associate a new QtDemuxStream that contains all the info
+  * about the trak.
+@@ -7427,10 +7513,27 @@ qtdemux_parse_trak (GstQTDemux * qtdemux, GNode * trak)
+       GST_FOURCC_ARGS (stream->fourcc));
+   GST_LOG_OBJECT (qtdemux, "stsd type len:      %d", len);
+ 
+-  if ((fourcc == FOURCC_drms) || (fourcc == FOURCC_drmi) ||
+-      ((fourcc & 0x00FFFFFF) == GST_MAKE_FOURCC ('e', 'n', 'c', 0)))
++  if ((fourcc == FOURCC_drms) || (fourcc == FOURCC_drmi))
+     goto error_encrypted;
+ 
++  /* get the real fourcc */
++  if ((fourcc == FOURCC_encv) || (fourcc == FOURCC_enca)) {
++    GNode * encx;
++
++    /* We need to find the real fourcc which is on the encx atom itself */
++    encx = qtdemux_tree_get_child_by_type (stsd, fourcc);
++    if (!encx) {
++      goto corrupt_file;
++    }
++
++    if (!qtdemux_parse_encx (qtdemux, stream, encx, &fourcc))
++      goto corrupt_file;
++
++    stream->fourcc = fourcc;
++    GST_LOG_OBJECT (qtdemux, "track decrypted format %" GST_FOURCC_FORMAT,
++        GST_FOURCC_ARGS (stream->fourcc));
++  }
++
+   if (stream->subtype == FOURCC_vide) {
+     guint32 w = 0, h = 0;
+     gboolean gray;
+diff --git a/gst/isomp4/qtdemux_types.c b/gst/isomp4/qtdemux_types.c
+index a47d5ae..5dee5a5 100644
+--- a/gst/isomp4/qtdemux_types.c
++++ b/gst/isomp4/qtdemux_types.c
+@@ -182,7 +182,11 @@ static const QtNodeType qt_node_types[] = {
+   {FOURCC_chap, "Chapter Reference"},
+   {FOURCC_btrt, "Bitrate information", 0},
+   {FOURCC_frma, "Audio codec format", 0},
++  {FOURCC_encv, "Encrypted video", 0, },
++  {FOURCC_enca, "Encrypted audio", 0, },
++  {FOURCC_sinf, "Protection Scheme Information Box", QT_FLAG_CONTAINER,},
+   {0, "unknown", 0,},
++  {FOURCC_pssh, "Protection System Specific Header", 0, },
+ };
+ 
+ static const int n_qt_node_types =

--- a/package/qt5/qt5webkit/Config.in
+++ b/package/qt5/qt5webkit/Config.in
@@ -75,8 +75,8 @@ config BR2_QT5WEBKIT_USE_GSTREAMER
 config BR2_QT5WEBKIT_USE_ENCRYPTED_MEDIA
 	bool "encrypted-media"
 	depends on BR2_QT5WEBKIT_USE_GSTREAMER
-	depends on BR2_PACKAGE_DXDRM
-	default n
+	select BR2_PACKAGE_OPENSSL
+	default y
 	help
 	  Enable Encrypted Media Extensions.
 


### PR DESCRIPTION
ClearKey requires qtdemux from gstreamer plugins good to be patched and qtwebkit to link with openssl crypto library.